### PR TITLE
feat: add RL scheduler plugin

### DIFF
--- a/root/kubernetes-scheduler-simulator/app.py
+++ b/root/kubernetes-scheduler-simulator/app.py
@@ -97,9 +97,13 @@ with main_col:
     st.markdown(f"**Using Input Directory:** `{input_dir_choice}`")
 
     policy = st.selectbox("Select Scheduling Policy", POLICIES)
-    gpu_sel = st.selectbox("GPU Selection", GPU_MODES)
-    dimext = st.selectbox("Dimension Extension", DIMEXT_MODES)
-    norm = st.selectbox("Normalization", NORM_MODES)
+    gpu_sel = st.selectbox("GPU Selection", GPU_MODES, disabled=policy == "RlSched")
+    dimext = st.selectbox("Dimension Extension", DIMEXT_MODES, disabled=policy == "RlSched")
+    norm = st.selectbox("Normalization", NORM_MODES, disabled=policy == "RlSched")
+    if policy == "RlSched":
+        gpu_sel = "<none>"
+        dimext = "<none>"
+        norm = "<none>"
 
     rl_endpoint = ""
     rl_timeout = 0

--- a/root/kubernetes-scheduler-simulator/experiments/run_scripts/expected_run_scripts_0511.sh
+++ b/root/kubernetes-scheduler-simulator/experiments/run_scripts/expected_run_scripts_0511.sh
@@ -19,6 +19,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/42" && mkdir
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -36,6 +39,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/42" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -55,6 +61,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/42" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -72,6 +81,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/42" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -91,6 +103,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/42" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -108,6 +123,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/42" && m
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -127,6 +145,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/42" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -144,6 +165,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/42" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -163,6 +187,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/42" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -180,6 +207,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/42" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -199,6 +229,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/42" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -216,6 +249,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/42" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -235,6 +271,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/42" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -252,6 +291,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/42" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -271,6 +313,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/42" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -288,6 +333,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/42" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -307,6 +355,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/42" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -324,6 +375,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/43" && mkdir
 
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -343,6 +397,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/43" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -360,6 +417,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/43" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -379,6 +439,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/43" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -396,6 +459,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/43" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -415,6 +481,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/43" && m
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -432,6 +501,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/43" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -451,6 +523,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/43" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -468,6 +543,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/43" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -487,6 +565,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/43" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -504,6 +585,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/43" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -523,6 +607,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/43" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -540,6 +627,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/43" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -559,6 +649,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/43" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -576,6 +669,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/43" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -595,6 +691,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/43" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -612,6 +711,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/43" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -631,6 +733,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/44" && mkdir
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -648,6 +753,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/44" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -667,6 +775,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/44" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -684,6 +795,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/44" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -703,6 +817,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/44" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -720,6 +837,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/44" && m
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -739,6 +859,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/44" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -756,6 +879,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/44" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -775,6 +901,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/44" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -792,6 +921,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/44" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -811,6 +943,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/44" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -828,6 +963,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/44" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -847,6 +985,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/44" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -864,6 +1005,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/44" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -883,6 +1027,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/44" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -900,6 +1047,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/44" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -919,6 +1069,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/44" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -936,6 +1089,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/45" && mkdir
 
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -955,6 +1111,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/45" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -972,6 +1131,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/45" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -991,6 +1153,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/45" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1008,6 +1173,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/45" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1027,6 +1195,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/45" && m
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1044,6 +1215,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/45" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1063,6 +1237,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/45" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1080,6 +1257,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/45" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1099,6 +1279,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/45" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1116,6 +1299,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/45" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1135,6 +1321,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/45" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1152,6 +1341,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/45" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1171,6 +1363,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/45" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1188,6 +1383,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/45" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1207,6 +1405,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/45" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1224,6 +1425,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/45" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1243,6 +1447,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/46" && mkdir
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1260,6 +1467,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/46" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1279,6 +1489,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/46" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1296,6 +1509,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/46" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1315,6 +1531,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/46" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1332,6 +1551,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/46" && m
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1351,6 +1573,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/46" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1368,6 +1593,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/46" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1387,6 +1615,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/46" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1404,6 +1635,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/46" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1423,6 +1657,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/46" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1440,6 +1677,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/46" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1459,6 +1699,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/46" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1476,6 +1719,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/46" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1495,6 +1741,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/46" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1512,6 +1761,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/46" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1531,6 +1783,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/46" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1548,6 +1803,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/47" && mkdir
 
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1567,6 +1825,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/47" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1584,6 +1845,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/47" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1603,6 +1867,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/47" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1620,6 +1887,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/47" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1639,6 +1909,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/47" && m
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1656,6 +1929,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/47" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1675,6 +1951,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/47" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1692,6 +1971,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/47" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1711,6 +1993,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/47" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1728,6 +2013,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/47" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1747,6 +2035,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/47" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1764,6 +2055,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/47" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1783,6 +2077,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/47" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1800,6 +2097,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/47" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1819,6 +2119,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/47" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1836,6 +2139,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/47" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1855,6 +2161,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/48" && mkdir
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1872,6 +2181,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/48" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1891,6 +2203,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/48" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1908,6 +2223,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/48" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1927,6 +2245,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/48" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1944,6 +2265,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/48" && m
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1963,6 +2287,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/48" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1980,6 +2307,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/48" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1999,6 +2329,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/48" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2016,6 +2349,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/48" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2035,6 +2371,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/48" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2052,6 +2391,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/48" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2071,6 +2413,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/48" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2088,6 +2433,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/48" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2107,6 +2455,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/48" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2124,6 +2475,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/48" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2143,6 +2497,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/48" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2160,6 +2517,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/49" && mkdir
 
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2179,6 +2539,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/49" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2196,6 +2559,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/49" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2215,6 +2581,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/49" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2232,6 +2601,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/49" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2251,6 +2623,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/49" && m
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2268,6 +2643,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/49" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2287,6 +2665,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/49" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2304,6 +2685,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/49" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2323,6 +2707,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/49" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2340,6 +2727,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/49" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2359,6 +2749,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/49" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2376,6 +2769,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/49" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2395,6 +2791,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/49" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2412,6 +2811,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/49" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2431,6 +2833,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/49" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2448,6 +2853,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/49" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2467,6 +2875,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/50" && mkdir
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2484,6 +2895,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/50" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2503,6 +2917,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/50" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2520,6 +2937,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/50" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2539,6 +2959,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/50" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2556,6 +2979,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/50" && m
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2575,6 +3001,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/50" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2592,6 +3021,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/50" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2611,6 +3043,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/50" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2628,6 +3063,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/50" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2647,6 +3085,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/50" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2664,6 +3105,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/50" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2683,6 +3127,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/50" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2700,6 +3147,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/50" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2719,6 +3169,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/50" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2736,6 +3189,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/50" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2755,6 +3211,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/50" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2772,6 +3231,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/51" && mkdir
 
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2791,6 +3253,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/51" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2808,6 +3273,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/51" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2827,6 +3295,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/51" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2844,6 +3315,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/51" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2863,6 +3337,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/51" && m
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2880,6 +3357,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/51" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2899,6 +3379,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/51" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2916,6 +3399,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/51" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2935,6 +3421,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/51" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2952,6 +3441,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/51" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2971,6 +3463,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/51" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2988,6 +3483,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/51" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -3007,6 +3505,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/51" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -3024,6 +3525,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/51" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -3043,6 +3547,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/51" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -3060,4 +3567,7 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/51" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 

--- a/root/kubernetes-scheduler-simulator/experiments/run_scripts/generate_run_scripts.py
+++ b/root/kubernetes-scheduler-simulator/experiments/run_scripts/generate_run_scripts.py
@@ -5,6 +5,8 @@
 DATE = "2023_0511" # Used as the folder name under experiments/ to hold all log results. To avoid collision of repeated experiments, may change date or append _v1, _v2, etc.
 REMARK = "Artifacts"
 REPEAT =10 # Number of repetitive experiments.
+RL_ENDPOINT = "http://127.0.0.1:5000"  # Endpoint for external RL scheduler
+RL_TIMEOUT_MS = 0  # Optional timeout value passed to the RL scheduler
 FILELIST = [
     #: Main results in Fig. 7 and 9
     "data/openb_pod_list_default",
@@ -37,6 +39,7 @@ AllMethodList = [
     ["04", "GpuPacking", "<none>", "<none>", "<none>"],
     ["05", "BestFit", "<none>", "<none>", "<none>"],
     ["06", "FGD", "<self>", "share", "max"],
+    ["07", "RlSched", "<none>", "<none>", "<none>"],
 ]
 
 AllMethodDict = {}
@@ -56,6 +59,7 @@ MethodList = [
     ["04", "GpuPacking", "<none>", "<none>", "<none>"],
     ["05", "BestFit", "<none>", "<none>", "<none>"],
     ["06", "FGD", "<self>", "share", "max"],
+    ["07", "RlSched", "<none>", "<none>", "<none>"],
 ]
 
 def get_dir_name_from_method(method_input):
@@ -111,6 +115,9 @@ def generate_run_scripts(asyncc=True, parallel=16):
                     outstr += '-gpusel %s ' % gsm if gsm != "<none>" else ''
                     outstr += '-dimext %s ' % dem if dem != "<none>" else ''
                     outstr += '-norm %s ' % nm if nm != "<none>" else ''
+                    if policy == "RlSched":
+                        outstr += '--rl-endpoint %s ' % RL_ENDPOINT if RL_ENDPOINT else ''
+                        outstr += '--rl-timeout-ms %s ' % RL_TIMEOUT_MS if RL_TIMEOUT_MS else ''
                     outstr += '-tune %s ' % tune_ratio if tune_ratio else ''
                     outstr += '-tuneseed %s ' % tune_seed if tune_seed else ''
                     outstr += "--shuffle-pod=true " if SHUFFLE_POD else ""

--- a/root/kubernetes-scheduler-simulator/experiments/run_scripts/run_scripts_0511.sh
+++ b/root/kubernetes-scheduler-simulator/experiments/run_scripts/run_scripts_0511.sh
@@ -19,6 +19,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/42" && mkdir
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -36,6 +39,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/42" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -55,6 +61,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/42" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -72,6 +81,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/42" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -91,6 +103,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/42" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -108,6 +123,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/42" && m
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -127,6 +145,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/42" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -144,6 +165,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/42" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -163,6 +187,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/42" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -180,6 +207,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/42" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -199,6 +229,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/42" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -216,6 +249,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/42" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -235,6 +271,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/42" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -252,6 +291,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/42" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -271,6 +313,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/42" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -288,6 +333,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/42" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -307,6 +355,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/42" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/42" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 42 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -324,6 +375,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/43" && mkdir
 
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -343,6 +397,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/43" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -360,6 +417,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/43" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -379,6 +439,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/43" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -396,6 +459,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/43" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -415,6 +481,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/43" && m
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -432,6 +501,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/43" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -451,6 +523,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/43" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -468,6 +543,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/43" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -487,6 +565,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/43" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -504,6 +585,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/43" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -523,6 +607,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/43" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -540,6 +627,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/43" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -559,6 +649,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/43" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -576,6 +669,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/43" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -595,6 +691,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/43" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -612,6 +711,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/43" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/43" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 43 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -631,6 +733,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/44" && mkdir
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -648,6 +753,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/44" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -667,6 +775,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/44" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -684,6 +795,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/44" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -703,6 +817,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/44" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -720,6 +837,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/44" && m
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -739,6 +859,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/44" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -756,6 +879,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/44" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -775,6 +901,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/44" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -792,6 +921,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/44" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -811,6 +943,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/44" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -828,6 +963,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/44" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -847,6 +985,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/44" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -864,6 +1005,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/44" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -883,6 +1027,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/44" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -900,6 +1047,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/44" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -919,6 +1069,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/44" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/44" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 44 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -936,6 +1089,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/45" && mkdir
 
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -955,6 +1111,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/45" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -972,6 +1131,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/45" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -991,6 +1153,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/45" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1008,6 +1173,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/45" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1027,6 +1195,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/45" && m
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1044,6 +1215,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/45" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1063,6 +1237,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/45" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1080,6 +1257,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/45" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1099,6 +1279,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/45" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1116,6 +1299,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/45" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1135,6 +1321,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/45" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1152,6 +1341,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/45" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1171,6 +1363,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/45" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1188,6 +1383,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/45" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1207,6 +1405,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/45" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1224,6 +1425,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/45" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/45" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 45 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1243,6 +1447,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/46" && mkdir
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1260,6 +1467,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/46" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1279,6 +1489,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/46" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1296,6 +1509,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/46" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1315,6 +1531,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/46" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1332,6 +1551,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/46" && m
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1351,6 +1573,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/46" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1368,6 +1593,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/46" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1387,6 +1615,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/46" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1404,6 +1635,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/46" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1423,6 +1657,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/46" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1440,6 +1677,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/46" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1459,6 +1699,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/46" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1476,6 +1719,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/46" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1495,6 +1741,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/46" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1512,6 +1761,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/46" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1531,6 +1783,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/46" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/46" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 46 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1548,6 +1803,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/47" && mkdir
 
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1567,6 +1825,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/47" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1584,6 +1845,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/47" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1603,6 +1867,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/47" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1620,6 +1887,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/47" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1639,6 +1909,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/47" && m
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1656,6 +1929,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/47" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1675,6 +1951,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/47" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1692,6 +1971,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/47" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1711,6 +1993,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/47" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1728,6 +2013,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/47" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1747,6 +2035,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/47" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1764,6 +2055,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/47" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1783,6 +2077,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/47" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1800,6 +2097,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/47" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1819,6 +2119,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/47" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1836,6 +2139,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/47" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/47" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 47 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1855,6 +2161,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/48" && mkdir
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1872,6 +2181,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/48" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1891,6 +2203,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/48" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1908,6 +2223,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/48" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1927,6 +2245,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/48" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1944,6 +2265,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/48" && m
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1963,6 +2287,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/48" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -1980,6 +2307,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/48" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -1999,6 +2329,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/48" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2016,6 +2349,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/48" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2035,6 +2371,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/48" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2052,6 +2391,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/48" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2071,6 +2413,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/48" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2088,6 +2433,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/48" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2107,6 +2455,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/48" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2124,6 +2475,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/48" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2143,6 +2497,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/48" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/48" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 48 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2160,6 +2517,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/49" && mkdir
 
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2179,6 +2539,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/49" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2196,6 +2559,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/49" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2215,6 +2581,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/49" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2232,6 +2601,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/49" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2251,6 +2623,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/49" && m
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2268,6 +2643,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/49" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2287,6 +2665,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/49" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2304,6 +2685,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/49" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2323,6 +2707,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/49" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2340,6 +2727,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/49" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2359,6 +2749,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/49" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2376,6 +2769,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/49" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2395,6 +2791,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/49" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2412,6 +2811,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/49" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2431,6 +2833,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/49" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2448,6 +2853,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/49" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/49" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 49 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2467,6 +2875,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/50" && mkdir
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2484,6 +2895,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/50" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2503,6 +2917,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/50" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2520,6 +2937,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/50" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2539,6 +2959,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/50" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2556,6 +2979,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/50" && m
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2575,6 +3001,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/50" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2592,6 +3021,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/50" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2611,6 +3043,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/50" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2628,6 +3063,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/50" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2647,6 +3085,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/50" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2664,6 +3105,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/50" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2683,6 +3127,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/50" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2700,6 +3147,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/50" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2719,6 +3169,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/50" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2736,6 +3189,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/50" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2755,6 +3211,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/50" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/50" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 50 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2772,6 +3231,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_default/05-BestFit/1.3/51" && mkdir
 
 # 06, FGD, FGD, share, max @ openb_pod_list_default
 EXPDIR="experiments/2023_0511/openb_pod_list_default/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_default
+EXPDIR="experiments/2023_0511/openb_pod_list_default/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_default -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2791,6 +3253,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/05-BestFit/1.3/51" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu050
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu050
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu050/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu050 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2808,6 +3273,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/05-BestFit/1.3/51" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu100
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu100
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu100/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2827,6 +3295,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/05-BestFit/1.3/51" && mkdir 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu200
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu200
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu200/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu200 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2844,6 +3315,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/05-BestFit/1.3/51" && mkdir 
 
 # 06, FGD, FGD, share, max @ openb_pod_list_cpu250
 EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_cpu250
+EXPDIR="experiments/2023_0511/openb_pod_list_cpu250/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_cpu250 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2863,6 +3337,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/05-BestFit/1.3/51" && m
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare100
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare100
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare100/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare100 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2880,6 +3357,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/05-BestFit/1.3/51" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare40
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare40
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare40/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2899,6 +3379,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/05-BestFit/1.3/51" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare60
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare60
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare60/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare60 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2916,6 +3399,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/05-BestFit/1.3/51" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpushare80
 EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpushare80
+EXPDIR="experiments/2023_0511/openb_pod_list_gpushare80/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpushare80 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2935,6 +3421,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/05-BestFit/1.3/51" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec10
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec10
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec10/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec10 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2952,6 +3441,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/05-BestFit/1.3/51" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec20
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec20
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec20/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -2971,6 +3463,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/05-BestFit/1.3/51" && mkd
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec25
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec25
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec25/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec25 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -2988,6 +3483,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/05-BestFit/1.3/51" && mkd
 
 # 06, FGD, FGD, share, max @ openb_pod_list_gpuspec33
 EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_gpuspec33
+EXPDIR="experiments/2023_0511/openb_pod_list_gpuspec33/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_gpuspec33 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -3007,6 +3505,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/05-BestFit/1.3/51" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu20
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu20
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu20/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu20 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -3024,6 +3525,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/05-BestFit/1.3/51" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu30
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu30
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu30/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu30 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
@@ -3043,6 +3547,9 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/05-BestFit/1.3/51" && mk
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu40
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu40
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu40/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu40 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
 # 01, Random, random, <none>, <none> @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/01-Random/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -Random 1000 -gpusel random -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 
@@ -3060,4 +3567,7 @@ EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/05-BestFit/1.3/51" && mk
 
 # 06, FGD, FGD, share, max @ openb_pod_list_multigpu50
 EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/06-FGD/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -FGD 1000 -gpusel FGD -dimext share -norm max -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
+
+# 07, RlSched, <none>, <none>, <none> @ openb_pod_list_multigpu50
+EXPDIR="experiments/2023_0511/openb_pod_list_multigpu50/07-RlSched/1.3/51" && mkdir -p ${EXPDIR} && touch "${EXPDIR}/terminal.out" && python3 scripts/generate_config_and_run.py -d "${EXPDIR}" -e -b -f data/openb_pod_list_multigpu50 -RlSched 1000 --rl-endpoint http://127.0.0.1:5000 -tune 1.3 -tuneseed 51 --shuffle-pod=true -z "${EXPDIR}/snapshot/ds01" | tee -a "${EXPDIR}/terminal.out" && python3 scripts/analysis.py -f -g ${EXPDIR} | tee -a "${EXPDIR}/terminal.out" 
 


### PR DESCRIPTION
## Summary
- disable GPU-related settings when RlSched is selected in the UI and allow providing its endpoint and timeout
- include RlSched in the experiment script generator and add default RL service parameters

## Testing
- `go test ./...`
- `python3 experiments/run_scripts/generate_run_scripts.py > experiments/run_scripts/run_scripts_0511.sh`


------
https://chatgpt.com/codex/tasks/task_e_68995269de1c83279fe682ce0b96a997